### PR TITLE
Bump to 6.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "icclim" %}
-{% set version = "6.1.5" %}
+{% set version = "6.2.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/icclim-{{ version }}.tar.gz
-  sha256: fd3be4a34ba30a1fe8e11bfcb75cd0b5cb70fc45800a11fdf65146357bb8c0c4
+  sha256: 782f09238157951beee029f6344d1b4741fb40c4d29b9ceb7e35233f7930394b
 
 build:
   number: 0
@@ -28,7 +28,7 @@ requirements:
     - numpy
     - pyyaml
     - xarray
-    - xclim >=0.38
+    - xclim ==0.40
     - rechunker >=0.3, !=0.4
     - pandas >=1.3
     - dateparser


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* n/a Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Mainly adapt icclim to the xclim 0.40.0 release.
Important change, now xclim will be pin to an exact version instead of using new version or above (e.g. `xclim>=0.39`).

This is necessary to ensure icclim's older versions can still be installed even when xclim make breaking changes in latest versions.


<!--
Please add any other relevant info below:
-->
